### PR TITLE
Add missing case to reasonMessage method inside NonNormalizable exception

### DIFF
--- a/src/Gtin/NonNormalizable.php
+++ b/src/Gtin/NonNormalizable.php
@@ -47,6 +47,9 @@ class NonNormalizable extends \InvalidArgumentException
             case self::CODE_PREFIX:
                 $message = 'Prefix is invalid';
                 break;
+            case self::CODE_CHECKSUM:
+                $message = 'Checksum is invalid';
+                break;
             default:
                 $message = 'Invalid argument has been passed';
                 break;


### PR DESCRIPTION
There was one missing case for reason message resolving - Invalid checksum