### PR TITLE
Enable PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ php:
     - '7.2'
     - '7.3'
     - '7.4'
+    - '8.0'
+    - nightly
 
 before_install:
     - mkdir -p build/logs

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ before_install:
 
 install:
     - composer self-update --ansi --no-interaction
-    - composer install --ansi --no-interaction --no-suggest
+    - composer install --ansi --no-interaction
 
 before_script:
     - vendor/bin/phpstan analyse --ansi --no-progress

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ php:
     - '7.3'
     - '7.4'
     - '8.0'
-    - nightly
 
 before_install:
     - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "sort-packages": true
     },
     "require": {
-        "php": "^7.1"
+        "php": "^7.1|^8.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^0.12.37",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12.37",
         "phpunit/phpunit": "^7.3 || ^8.0 || ^9.0",
-        "vimeo/psalm": "^3.13|^4.3"
+        "vimeo/psalm": "^4.3"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "phpstan/phpstan": "^0.12.37",
         "phpunit/phpunit": "^7.3 || ^8.0 || ^9.0",
-        "vimeo/psalm": "^3.13"
+        "vimeo/psalm": "^3.13|^4.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This PR increases the version range of supported PHP versions to include 8.0, and adds testing on 8.0. This also required allowing psalm version 4. All tests pass.